### PR TITLE
Report active status when the charm is ready

### DIFF
--- a/reactive/kubeflow_pytorch_operator.py
+++ b/reactive/kubeflow_pytorch_operator.py
@@ -8,6 +8,11 @@ from charms.reactive import when, when_not
 from charms import layer
 
 
+@when('charm.kubeflow-pytorch-operator.started')
+def charm_ready():
+    layer.status.active('')
+
+
 @when('config.changed')
 def update_config():
     clear_flag('charm.kubeflow-pytorch-operator.started')


### PR DESCRIPTION
When charm has pushed the pod spec, report status as active so juju can correctly reflect the unit status when the container has started.